### PR TITLE
make htslib location configurable

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -3,7 +3,7 @@
 ## to provide a way for the user to supply additional arguments.
 ACLOCAL_AMFLAGS = -I m4 ${ACLOCAL_FLAGS}
 
-AM_CPPFLAGS = -fopenmp -I ../htslib/ -I ../../htslib/htslib -pipe -D__STDC_LIMIT_MACROS -Wall -Wno-unused-local-typedefs -Wno-enum-compare -fpic -O2 
+AM_CPPFLAGS = -fopenmp -pipe -D__STDC_LIMIT_MACROS -Wall -Wno-unused-local-typedefs -Wno-enum-compare -fpic -O2 
 
 noinst_HEADERS = \
 	Constant.h pException.h \
@@ -24,4 +24,4 @@ demuxlet_SOURCES = \
 	tsv_reader.cpp \
 	cmd_cram_demuxlet.cpp
 
-demuxlet_LDADD = ../htslib/libhts.a -lpthread -llzma -lz -lbz2 -lgomp -lcurl -lcrypto
+demuxlet_LDADD = -lhts -lpthread -llzma -lz -lbz2 -lgomp -lcurl -lcrypto

--- a/README.md
+++ b/README.md
@@ -8,9 +8,7 @@ Genetic multiplexing of barcoded single cell RNA-seq
 
 ### Installing demuxlet
 
-Before installing demuxlet, you need to install [htslib](https://github.com/samtools/htslib) in the same directory you want to install demuxlet (i.e. demuxlet and htslib should be siblings).
-
-After installing htslib, you can clone the current snapshot of this repository to install as well
+Before installing demuxlet, you need to install [htslib](https://github.com/samtools/htslib). If you do not install this to standard system paths, you'll need to pass the directory for header files and compiled library file to configure. For example, if you downloaded and compiled htslib in `/opt/htslib`, run `./configure CPPFLAGS=-I/opt/htslib LDFLAGS=-L/opt/htslib`.
 
 <pre>
 $ git clone https://github.com/statgen/demuxlet.git

--- a/configure.ac
+++ b/configure.ac
@@ -17,6 +17,8 @@ AC_CONFIG_MACRO_DIR([m4])
 AC_PROG_CXX
 
 AC_CHECK_HEADERS([limits.h stddef.h stdint.h stdlib.h string.h unistd.h])
+AC_CHECK_HEADERS([htslib/kseq.h htslib/kstring.h htslib/khash.h htslib/hts.h htslib/sam.h],
+		 [], [AC_MSG_ERROR([htslib headers not found. Please download and compile, and pass CPPFLAGS=-I<htslib_path>])])
 
 AC_HEADER_STDBOOL
 AC_C_INLINE
@@ -38,6 +40,7 @@ AC_FUNC_REALLOC
 AC_FUNC_STRTOD
 AC_CHECK_FUNCS([floor gethostname memset pow select sqrt strchr strstr strtol])
 AC_CHECK_LIB(z, gzopen, [], [AC_MSG_ERROR([libz.{so,a} was not found. Please install zlib at http://www.zlib.net/ first])])
+AC_CHECK_LIB(hts, hts_open, [], [AC_MSG_ERROR([libhts.{so,a} was not found. Please download and compile htslib and pass LDFLAGS=-L<htslib_path>])])
 AC_CHECK_LIB([m],[erf],[AC_DEFINE([HAVE_ERF],[1],[libm includes erf])])
 AC_CHECK_LIB([m],[erfc],[AC_DEFINE([HAVE_ERFC],[1],[libm includes erfc])])
 


### PR DESCRIPTION
Previously, the autotools setup required that htslib be in a parallel
directory. Now the location is controlled through standard CPPFLAGS
and LDFLAGS configuration variables.