### PR TITLE
[bugfix] variant sites may be skipped

### DIFF
--- a/cmd_cram_demuxlet.cpp
+++ b/cmd_cram_demuxlet.cpp
@@ -199,7 +199,7 @@ int32_t main(int32_t argc, char** argv) {
       continue;
     }
 
-    int32_t n_cleared = vr.clear_buffer_before( bcf_hdr_id2name(vr.cdr.hdr, vr.cursor()->rid), sr.cursor()->core.pos );
+    int32_t n_cleared = vr.clear_buffer_before(  bam_get_chrom(sr.hdr, sr.cursor()), sr.cursor()->core.pos );
     //for(int32_t i=ibeg; i < ibeg+n_cleared; ++i) {
     //  v_umis.clear();
     //}


### PR DESCRIPTION
If the BAM file has reads from contigs/chromosomes prior to the first variant in the VCF, but those reads have position greater than the first variant in the VCF, then the first variant may be skipped.  For example, if the BAM file has a read from `chr3:100-200` while the VCF has a variant at `chr4:50`.  The variant is latter in the genome by coordinate, but if we only compare the position (i.e. 100 for the read and 50 for the variant), it is "earlier". 

The issue stemmed from the fact that read's contig was not used when clearing the variant buffer, but instead the variant itself!